### PR TITLE
Add Plasma applet package skeleton for openwheel-gadget

### DIFF
--- a/openwheel-gadget/CMakeLists.txt
+++ b/openwheel-gadget/CMakeLists.txt
@@ -1,2 +1,14 @@
-cmake_minimum_required(VERSION 3.0)
-project(openwheel-gadget C)
+cmake_minimum_required(VERSION 3.16)
+
+project(openwheel-gadget)
+
+find_package(ECM 5.240 REQUIRED NO_MODULE)
+set(CMAKE_MODULE_PATH ${ECM_MODULE_PATH})
+
+include(KDEInstallDirs)
+include(KDECMakeSettings)
+include(KDECompilerSettings NO_POLICY_SCOPE)
+
+find_package(KF6 REQUIRED COMPONENTS KPackage I18n)
+
+kpackage_install_package(package org.openwheel.gadget)

--- a/openwheel-gadget/package/contents/ui/main.qml
+++ b/openwheel-gadget/package/contents/ui/main.qml
@@ -1,0 +1,10 @@
+import QtQuick 2.15
+import org.kde.kirigami 2.20 as Kirigami
+import org.kde.plasma.plasmoid 2.0
+
+Kirigami.InlineMessage {
+    id: placeholder
+    type: Kirigami.MessageType.Information
+    text: i18n("OpenWheel gadget placeholder")
+    visible: true
+}

--- a/openwheel-gadget/package/metadata.json
+++ b/openwheel-gadget/package/metadata.json
@@ -1,0 +1,16 @@
+{
+  "KPackageStructure": "Plasma/Applet",
+  "KPlugin": {
+    "Id": "org.openwheel.gadget",
+    "Name": "OpenWheel Gadget",
+    "Description": "Placeholder Plasma applet for OpenWheel",
+    "Version": "0.1.0",
+    "Website": "https://example.com",
+    "License": "GPL-3.0-or-later",
+    "Authors": [
+      {
+        "Name": "OpenWheel"
+      }
+    ]
+  }
+}


### PR DESCRIPTION
### Motivation
- Provide an initial Plasma 6 KPackage skeleton so the gadget can be packaged and loaded as a Plasma applet for validation.
- Bring the CMake configuration in line with KDE/Plasma packaging helpers to enable proper installation via `KPackage`.

### Description
- Updated `openwheel-gadget/CMakeLists.txt` to require CMake 3.16, find `ECM` and `KF6` (including `KPackage` and `I18n`) and call `kpackage_install_package(package org.openwheel.gadget)`.
- Added `package/metadata.json` with `KPackageStructure` set to `Plasma/Applet` and basic plugin metadata for `org.openwheel.gadget`.
- Added a minimal `package/contents/ui/main.qml` containing a `Kirigami.InlineMessage` with i18n-ready text `i18n("OpenWheel gadget placeholder")` as a placeholder UI.

### Testing
- No automated tests or CI build were run for these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6962087608bc832b89f61ed59527aeb7)